### PR TITLE
Show selected products label on startup

### DIFF
--- a/CargaImagenes.UI/Form1.cs
+++ b/CargaImagenes.UI/Form1.cs
@@ -82,6 +82,7 @@ namespace CargaImagenes.UI
                 Size = new Size(cfg.Width, cfg.Height);
             }
             dgvProductos.Focus(); // Establecer foco inicial en DataGridView
+            UpdateCounters();    // Mostrar contador de productos seleccionados desde el inicio
         }
         #endregion
 


### PR DESCRIPTION
## Summary
- ensure the selected products counter is visible immediately on load

## Testing
- `dotnet build MotomaniaReportes.sln -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850e5a7de5c8324a8e86f5a08500819