### PR TITLE
Fix drag error with unique temp files

### DIFF
--- a/CargaImagenes.UI/Form1.cs
+++ b/CargaImagenes.UI/Form1.cs
@@ -1358,7 +1358,7 @@ namespace CargaImagenes.UI
                         var data = new DataObject();
                         data.SetData(DataFormats.Bitmap, pbProducto.Image);
 
-                        var file = IOPath.Combine(_tempImagePath, "drag_temp.jpg");
+                        var file = IOPath.Combine(_tempImagePath, $"drag_{Guid.NewGuid()}.jpg");
                         using (var fs = new IOFileStream(file, FileMode.Create, FileAccess.Write))
                         {
                             pbProducto.Image.Save(fs, ImageFormat.Jpeg);


### PR DESCRIPTION
## Summary
- ensure drag-and-drop uses unique temp file names

## Testing
- `dotnet build MotomaniaReportes.sln -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fc34c90ec8324be41a100fac3bb0b