### PR TITLE
Add command timeout configuration

### DIFF
--- a/CargaImagenes.Data/ConnectionConfig.cs
+++ b/CargaImagenes.Data/ConnectionConfig.cs
@@ -10,5 +10,10 @@ namespace CargaImagenes.Data
         /// Cadena de conexión a la base de datos.
         /// </summary>
         public string ConnectionString { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Tiempo máximo de espera para las operaciones de base de datos en segundos.
+        /// </summary>
+        public int CommandTimeout { get; set; } = 30;
     }
 }

--- a/CargaImagenes.Data/DatabaseService.cs
+++ b/CargaImagenes.Data/DatabaseService.cs
@@ -6,18 +6,23 @@ namespace CargaImagenes.Data
     public class DatabaseService : IDatabaseService
     {
         private readonly string _connectionString;
+        private readonly int _commandTimeout;
 
         public DatabaseService(ConnectionConfig config)
         {
             if (string.IsNullOrWhiteSpace(config.ConnectionString))
                 throw new ArgumentException("La cadena de conexión no puede estar vacía.", nameof(config));
             _connectionString = config.ConnectionString;
+            _commandTimeout = config.CommandTimeout;
         }
 
         public DataTable ExecuteQuery(string query)
         {
             using var connection = new SqlConnection(_connectionString);
-            using var command = new SqlCommand(query, connection);
+            using var command = new SqlCommand(query, connection)
+            {
+                CommandTimeout = _commandTimeout
+            };
             using var adapter = new SqlDataAdapter(command);
             var dt = new DataTable();
 
@@ -29,7 +34,10 @@ namespace CargaImagenes.Data
         public DataTable ExecuteQueryWithParameters(string query, Dictionary<string, object>? parameters = null)
         {
             using var connection = new SqlConnection(_connectionString);
-            using var command = new SqlCommand(query, connection);
+            using var command = new SqlCommand(query, connection)
+            {
+                CommandTimeout = _commandTimeout
+            };
 
             if (parameters != null)
             {
@@ -52,7 +60,10 @@ namespace CargaImagenes.Data
         public int ExecuteNonQuery(string query, Dictionary<string, object>? parameters = null)
         {
             using var connection = new SqlConnection(_connectionString);
-            using var command = new SqlCommand(query, connection);
+            using var command = new SqlCommand(query, connection)
+            {
+                CommandTimeout = _commandTimeout
+            };
 
             if (parameters != null)
             {
@@ -70,7 +81,10 @@ namespace CargaImagenes.Data
         public object? ExecuteScalar(string query, Dictionary<string, object>? parameters = null)
         {
             using var connection = new SqlConnection(_connectionString);
-            using var command = new SqlCommand(query, connection);
+            using var command = new SqlCommand(query, connection)
+            {
+                CommandTimeout = _commandTimeout
+            };
 
             if (parameters != null)
             {

--- a/CargaImagenes.UI/Program.cs
+++ b/CargaImagenes.UI/Program.cs
@@ -33,7 +33,11 @@ namespace CargaImagenes.UI
             var services = new ServiceCollection();
 
             // 2.1) Inyecta la configuración de conexión
-            services.AddSingleton(new ConnectionConfig { ConnectionString = connectionString });
+            services.AddSingleton(new ConnectionConfig
+            {
+                ConnectionString = connectionString,
+                CommandTimeout = 30
+            });
 
             // 2.2) Registra tu DatabaseService
             services.AddTransient<IDatabaseService, DatabaseService>();


### PR DESCRIPTION
## Summary
- add `CommandTimeout` property to `ConnectionConfig`
- use new timeout when creating `SqlCommand` in `DatabaseService`
- register default timeout in DI setup

## Testing
- `dotnet build MotomaniaReportes.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fd576511883249c2ec3ef3d2fb7fd