### PR TITLE
Optimize product image loading

### DIFF
--- a/CargaImagenes.UI/Form1.cs
+++ b/CargaImagenes.UI/Form1.cs
@@ -550,7 +550,7 @@ namespace CargaImagenes.UI
             {
                 ActualizarCamposDetalle(producto);
                 if (producto.TieneImagen && producto.Imagen == null)
-                    CargarImagenProducto(producto);
+                    CargarImagenesProductos(new[] { producto });
                 pbProducto.Image = producto.Imagen;
                 if (_ultimoProductoSeleccionado != null && _ultimoProductoSeleccionado.Id == producto.Id)
                     return;
@@ -1206,41 +1206,65 @@ namespace CargaImagenes.UI
         #region Manejo de Imágenes
         private void CargarImagenProducto(Producto producto, bool mostrarErrores = true)
         {
+            CargarImagenesProductos(new[] { producto }, mostrarErrores);
+        }
+
+        private void CargarImagenesProductos(IEnumerable<Producto> productos, bool mostrarErrores = true)
+        {
+            var productosParaCargar = productos
+                .Where(p => p.TieneImagen && p.Imagen == null)
+                .ToList();
+            if (productosParaCargar.Count == 0)
+                return;
+
             try
             {
-                const string query = "SELECT Imagen FROM ItemImage WHERE ItemID = @ItemID";
-                var parameters = new Dictionary<string, object> { ["@ItemID"] = producto.Id };
-                var dtImagen = _databaseService.ExecuteQueryWithParameters(query, parameters);
-                if (dtImagen.Rows.Count > 0 && dtImagen.Rows[0]["Imagen"] != DBNull.Value)
+                var paramNames = productosParaCargar
+                    .Select((p, i) => ($"@Id{i}", p.Id))
+                    .ToList();
+                var inClause = string.Join(",", paramNames.Select(t => t.Item1));
+                var query = $"SELECT ItemID, Imagen FROM ItemImage WHERE ItemID IN ({inClause})";
+                var parameters = paramNames.ToDictionary(t => t.Item1, t => (object)t.Item2);
+                var dtImagenes = _databaseService.ExecuteQueryWithParameters(query, parameters);
+                var imagenes = new Dictionary<int, byte[]>();
+                foreach (DataRow row in dtImagenes.Rows)
                 {
-                    var imageData = (byte[])dtImagen.Rows[0]["Imagen"];
-                    using var memStream = new MemoryStream(imageData);
-                    using var tempImg = SystemDrawingImage.FromStream(memStream);
-                    producto.Imagen = new Bitmap(tempImg);
-                    producto.ImagenMiniatura = producto.Imagen.GetThumbnailImage(80, 80, null, IntPtr.Zero);
-                    var tempPath = IOPath.Combine(_tempImagePath, $"temp_{producto.Id}.jpg");
-                    producto.RutaImagen = tempPath;
-                    if (File.Exists(tempPath))
-                        File.Delete(tempPath);
-                    using var fileStream = new IOFileStream(tempPath, FileMode.Create, FileAccess.Write);
-                    producto.Imagen.Save(fileStream, ImageFormat.Jpeg);
+                    if (row["Imagen"] != DBNull.Value)
+                        imagenes[(int)row["ItemID"]] = (byte[])row["Imagen"];
                 }
-                else
+
+                foreach (var producto in productosParaCargar)
                 {
-                    var rutaImagenDefecto = IOPath.Combine(_appSettings.DefaultImagePath, "no-image.png");
-                    if (File.Exists(rutaImagenDefecto))
+                    if (imagenes.TryGetValue(producto.Id, out var data))
                     {
-                        using var stream = new FileStream(rutaImagenDefecto, FileMode.Open, FileAccess.Read);
-                        using var tempImg = SystemDrawingImage.FromStream(stream);
+                        using var memStream = new MemoryStream(data);
+                        using var tempImg = SystemDrawingImage.FromStream(memStream);
                         producto.Imagen = new Bitmap(tempImg);
                         producto.ImagenMiniatura = producto.Imagen.GetThumbnailImage(80, 80, null, IntPtr.Zero);
+                        var tempPath = IOPath.Combine(_tempImagePath, $"temp_{producto.Id}.jpg");
+                        producto.RutaImagen = tempPath;
+                        if (File.Exists(tempPath))
+                            File.Delete(tempPath);
+                        using var fileStream = new IOFileStream(tempPath, FileMode.Create, FileAccess.Write);
+                        producto.Imagen.Save(fileStream, ImageFormat.Jpeg);
+                    }
+                    else
+                    {
+                        var rutaImagenDefecto = IOPath.Combine(_appSettings.DefaultImagePath, "no-image.png");
+                        if (File.Exists(rutaImagenDefecto))
+                        {
+                            using var stream = new FileStream(rutaImagenDefecto, FileMode.Open, FileAccess.Read);
+                            using var tempImg = SystemDrawingImage.FromStream(stream);
+                            producto.Imagen = new Bitmap(tempImg);
+                            producto.ImagenMiniatura = producto.Imagen.GetThumbnailImage(80, 80, null, IntPtr.Zero);
+                        }
                     }
                 }
             }
             catch (Exception ex)
             {
                 if (mostrarErrores)
-                    MessageBox.Show($"Error al cargar imagen del producto: {ex.Message}",
+                    MessageBox.Show($"Error al cargar imágenes: {ex.Message}",
                         "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
         }
@@ -1481,9 +1505,7 @@ namespace CargaImagenes.UI
                 {
                     await Task.Run(() =>
                     {
-                        foreach (var p in lista)
-                            if (p.TieneImagen && p.Imagen == null)
-                                CargarImagenProducto(p, false);
+                        CargarImagenesProductos(lista, false);
                         GeneradorCatalogoPdf.GenerarCatálogo(lista, sfd.FileName);
                     });
                 }


### PR DESCRIPTION
## Summary
- use new `CargarImagenesProductos` helper to fetch images for many items at once
- update selection and PDF generation to call the new bulk loader

## Testing
- `dotnet build MotomaniaReportes.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fd575bfb88324a7c7c80205c9d715