### PR TITLE
Always show connection form on startup

### DIFF
--- a/CargaImagenes.UI/FormConexion.cs
+++ b/CargaImagenes.UI/FormConexion.cs
@@ -34,14 +34,6 @@ namespace CargaImagenes.UI
                         txtUsuario.Text = config.User;
                         txtContrasena.Text = config.Password;
                         chkGuardarConfig.Checked = true;
-
-                        // Probar la conexión con la configuración cargada
-                        ConnectionString = ConstructConnectionString();
-                        if (ProbarConexion())
-                        {
-                            DialogResult = DialogResult.OK;
-                            Close();
-                        }
                     }
                 }
             }

--- a/CargaImagenes.UI/Program.cs
+++ b/CargaImagenes.UI/Program.cs
@@ -15,17 +15,10 @@ namespace CargaImagenes.UI
             string? connectionString;
             using (var formConexion = new FormConexion())
             {
-                if (ProbarConfiguracionGuardada(formConexion, out connectionString))
-                {
-                    // Si la conexión es exitosa, no mostramos el formulario
-                }
-                else
-                {
-                    // Si no hay conexión válida, mostramos el formulario
-                    if (formConexion.ShowDialog() != DialogResult.OK)
-                        return;
-                    connectionString = formConexion.ConnectionString;
-                }
+                if (formConexion.ShowDialog() != DialogResult.OK)
+                    return;
+
+                connectionString = formConexion.ConnectionString;
             }
 
             // 2) Construye el ServiceProvider
@@ -61,13 +54,6 @@ namespace CargaImagenes.UI
             // 4) Ejecuta el form con DI
             var mainForm = provider.GetRequiredService<Form1>();
             Application.Run(mainForm);
-        }
-
-        // Método para probar la configuración guardada
-        private static bool ProbarConfiguracionGuardada(FormConexion formConexion, out string? connectionString)
-        {
-            connectionString = formConexion.ConnectionString;
-            return !string.IsNullOrEmpty(connectionString) && formConexion.DialogResult == DialogResult.OK;
         }
     }
 }


### PR DESCRIPTION
## Summary
- Always display the connection form before launching the main application window
- Stop auto-closing the connection form when a saved configuration is loaded so users can review or modify it

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repositories not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688d328a896483249c1a273d21daa210